### PR TITLE
tab_switcher: Preserve selected position on closed tabs

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -184,11 +184,7 @@ impl TabSwitcherDelegate {
                 PaneEvent::AddItem { .. }
                 | PaneEvent::RemovedItem { .. }
                 | PaneEvent::Remove { .. } => tab_switcher.picker.update(cx, |picker, cx| {
-                    let selected_item_id = picker.delegate.selected_item_id();
                     picker.delegate.update_matches(cx);
-                    if let Some(item_id) = selected_item_id {
-                        picker.delegate.select_item(item_id, cx);
-                    }
                     cx.notify();
                 }),
                 _ => {}
@@ -198,6 +194,7 @@ impl TabSwitcherDelegate {
     }
 
     fn update_matches(&mut self, cx: &mut WindowContext) {
+        let selected_item_id = self.selected_item_id();
         self.matches.clear();
         let Some(pane) = self.pane.upgrade() else {
             return;
@@ -235,11 +232,15 @@ impl TabSwitcherDelegate {
             a_score.cmp(&b_score)
         });
 
-        if self.matches.len() > 1 {
-            if self.select_last {
-                self.selected_index = self.matches.len() - 1;
-            } else {
-                self.selected_index = 1;
+        if let Some(item_id) = selected_item_id {
+            self.selected_index = self.compute_selected_index(item_id);
+        } else {
+            if self.matches.len() > 1 {
+                if self.select_last {
+                    self.selected_index = self.matches.len() - 1;
+                } else {
+                    self.selected_index = 1;
+                }
             }
         }
     }
@@ -250,17 +251,22 @@ impl TabSwitcherDelegate {
             .map(|tab_match| tab_match.item.item_id())
     }
 
-    fn select_item(
-        &mut self,
-        item_id: EntityId,
-        cx: &mut ViewContext<Picker<TabSwitcherDelegate>>,
-    ) {
-        let selected_idx = self
+    fn compute_selected_index(&mut self, prev_selected_item_id: EntityId) -> usize {
+        if self.matches.is_empty() {
+            return 0;
+        }
+
+        // If the previously selected item is still in the list, select its new position.
+        if let Some(item_index) = self
             .matches
             .iter()
-            .position(|tab_match| tab_match.item.item_id() == item_id)
-            .unwrap_or(0);
-        self.set_selected_index(selected_idx, cx);
+            .position(|tab_match| tab_match.item.item_id() == prev_selected_item_id)
+        {
+            return item_index;
+        }
+
+        // Otherwise, try to preserve the previously selected index.
+        return self.selected_index.min(self.matches.len() - 1);
     }
 
     fn close_item_at(&mut self, ix: usize, cx: &mut ViewContext<Picker<TabSwitcherDelegate>>) {


### PR DESCRIPTION
See https://github.com/zed-industries/zed/discussions/22791 for full motivation.

When the user closes a tab, the tab switcher will now select the tab at the same position. This feature is especially relevant for keyboard users when you want to close multiple consecutive tabs with <Ctrl-Backspace>.

Closes #ISSUE

Release Notes:

- tab_switcher: Preserve selected position when tab is closed
